### PR TITLE
Skip disabled server integrations

### DIFF
--- a/LunaCompatServerPlugin/LunaCompatServer.cs
+++ b/LunaCompatServerPlugin/LunaCompatServer.cs
@@ -79,7 +79,7 @@ public class LunaCompatServer : LmpPlugin
                 if (isEnabled is bool and false)
                 {
                     _logger.Info($"{instance.PackageName} is disabled.");
-                    return;
+                    continue;
                 }
 
                 instance.Setup();


### PR DESCRIPTION
## Summary

When a server integration is disabled in `ModSettingsStructure.xml`, continue loading the remaining integrations instead of returning from `OnServerStart()`.

This keeps one disabled package from preventing later server integrations from being set up.

## Validation

- `TMPDIR=/home/sean/.cache/lunacompat-tmp TEMP=/home/sean/.cache/lunacompat-tmp TMP=/home/sean/.cache/lunacompat-tmp dotnet /usr/share/dotnet/sdk/8.0.125/MSBuild.dll LunaCompatServerPlugin/LunaCompatServerPlugin.csproj /restore /p:Configuration=Release /p:LMPServerRoot=/home/sean/.cache/lunacompat-lmp-server/LMPServer /p:SolutionDir="$PWD/" /p:UseSharedCompilation=false /nr:false /m:1 /v:minimal`
- `git diff --check HEAD^ HEAD`

No in-game, live server, or client project runtime pass was performed.