### PR TITLE
fix(SystemHeat): stop syncing LastUpdateTime; throttle continuous heat fields

### DIFF
--- a/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeat.xml
+++ b/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeat.xml
@@ -1,23 +1,31 @@
 ﻿<?xml version="1.0"?>
 <ModuleDefinition xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation="luna:schema ../../PartSyncSchema.xsd">
 	<Fields>
+		<!-- Loop temperature/flux readouts drift continuously during transients; throttle so they
+		     don't flood the log/network, while still updating roughly once per second for observers. -->
 		<FieldDefinition>
 			<FieldName>totalSystemTemperature</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
 		<FieldDefinition>
 			<FieldName>totalSystemFlux</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
+		<!-- Loop assignment; discrete, changes only on player action -->
 		<FieldDefinition>
 			<FieldName>currentLoopID</FieldName>
 		</FieldDefinition>
 		<FieldDefinition>
 			<FieldName>currentLoopTemperature</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
 		<FieldDefinition>
 			<FieldName>nominalLoopTemperature</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
 		<FieldDefinition>
 			<FieldName>currentLoopFlux</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
 	</Fields>
 </ModuleDefinition>

--- a/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatCryoTank.xml
+++ b/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatCryoTank.xml
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0"?>
 <ModuleDefinition xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation="luna:schema ../../PartSyncSchema.xsd">
 	<Fields>
-		<FieldDefinition>
-			<FieldName>LastUpdateTime</FieldName>
-		</FieldDefinition>
+		<!-- LastUpdateTime is a per-physics-tick simulation clock: it changes every FixedUpdate,
+		     so it can never be quieted by a throttle and just floods the log/network. It is still
+		     carried by LMP's periodic full-protovessel sync for load-time catch-up, so it is
+		     intentionally not synced as an incremental field. -->
 		<FieldDefinition>
 			<FieldName>CoolingAllowed</FieldName>
 		</FieldDefinition>

--- a/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatCryoTank.xml
+++ b/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatCryoTank.xml
@@ -2,9 +2,10 @@
 <ModuleDefinition xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation="luna:schema ../../PartSyncSchema.xsd">
 	<Fields>
 		<!-- LastUpdateTime is a per-physics-tick simulation clock: it changes every FixedUpdate,
-		     so it can never be quieted by a throttle and just floods the log/network. It is still
-		     carried by LMP's periodic full-protovessel sync for load-time catch-up, so it is
-		     intentionally not synced as an incremental field. -->
+		     so it can never be quieted by a throttle (it always fires at the interval ceiling) and
+		     just floods the log/network. It is re-seeded on FirstLoad and still carried by LMP's
+		     periodic full-protovessel sync for load-time catch-up, so it is intentionally not synced
+		     as an incremental field. -->
 		<FieldDefinition>
 			<FieldName>CoolingAllowed</FieldName>
 		</FieldDefinition>

--- a/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatFissionReactor.xml
+++ b/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatFissionReactor.xml
@@ -42,10 +42,11 @@
 		<FieldDefinition>
 			<FieldName>FirstLoad</FieldName>
 		</FieldDefinition>
-		<FieldDefinition>
-			<FieldName>LastUpdateTime</FieldName>
-			<MaxIntervalInMs>1000</MaxIntervalInMs>
-		</FieldDefinition>
+		<!-- LastUpdateTime is a per-physics-tick simulation clock: it changes every FixedUpdate,
+		     so it can never be quieted by a throttle (it always fires at the interval ceiling) and
+		     just floods the log/network. It is re-seeded on FirstLoad and still carried by LMP's
+		     periodic full-protovessel sync for load-time catch-up, so it is intentionally not synced
+		     as an incremental field. -->
 		<FieldDefinition>
 			<FieldName>CoreIntegrity</FieldName>
 			<MaxIntervalInMs>1000</MaxIntervalInMs>

--- a/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatSink.xml
+++ b/LunaCompat/XML_COMPAT/SystemHeat/ModuleSystemHeatSink.xml
@@ -4,12 +4,17 @@
 		<FieldDefinition>
 			<FieldName>storageEnabled</FieldName>
 		</FieldDefinition>
+		<!-- Stored heat / temperature drift continuously while absorbing/dumping; throttle to avoid
+		     flooding the log/network while still updating roughly once per second for observers. -->
 		<FieldDefinition>
 			<FieldName>heatStored</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
 		<FieldDefinition>
 			<FieldName>storageTemperature</FieldName>
+			<MaxIntervalInMs>1000</MaxIntervalInMs>
 		</FieldDefinition>
+		<!-- Player-set dump rate; discrete -->
 		<FieldDefinition>
 			<FieldName>heatStorageDumpRate</FieldName>
 		</FieldDefinition>


### PR DESCRIPTION
## Summary

SystemHeat parts were flooding `KSP.log` (and the network) with continuous
`VesselPartSyncField` updates. The worst offender is `LastUpdateTime`, a
per-physics-tick simulation clock that advances every `FixedUpdate`. Because it
changes every frame, it can never be quieted by a `MaxIntervalInMs` throttle — it
just fires at the interval ceiling forever (e.g. ~1/sec/reactor even at 1000ms).
This PR removes that field from incremental sync and brings the remaining
unthrottled analog readouts in line with the throttles the reactor config already
uses.

Observed before the fix (4 reactors, repeating every tick):

[LOG] [LMP]: Field LastUpdateTime in module ModuleSystemHeatFissionEngine from part 2050077044 has a new DOUBLE value of 15797358.2526392.

## Changes

**Remove `LastUpdateTime` from incremental field sync**
- `ModuleSystemHeatFissionReactor.xml` (also affects `ModuleSystemHeatFissionEngine`,
  which inherits this config) — was throttled to 1000ms but still streamed every second.
- `ModuleSystemHeatCryoTank.xml` — was completely unthrottled (latent identical
  spammer once a cryotank begins boil-off).

**Throttle previously-unthrottled continuous analog fields to 1000ms** (for
consistency with the reactor config's existing throttles)
- `ModuleSystemHeat.xml` (present on every SystemHeat part): `totalSystemTemperature`,
  `totalSystemFlux`, `currentLoopTemperature`, `nominalLoopTemperature`,
  `currentLoopFlux`. `currentLoopID` left unthrottled (discrete loop assignment).
- `ModuleSystemHeatSink.xml`: `heatStored`, `storageTemperature`. `storageEnabled`
  (bool) and `heatStorageDumpRate` (player setpoint) left unchanged.

**Unchanged** — only discrete state / player setpoints, no sync churn:
`ModuleSystemHeatExchanger.xml`, `ModuleSystemHeatMultiJettison.xml`,
`ModuleSystemHeatRadiator.xml`, and the already-throttled reactor analog fields.

## Why removing `LastUpdateTime` is safe

- SystemHeat re-seeds `LastUpdateTime` on `FirstLoad`.
- It is still carried by LMP's periodic full-protovessel sync, so a player loading
  your vessel from an unloaded state still gets a sane catch-up baseline.
- On a loaded vessel the observer's own `FixedUpdate` overwrites it immediately, so
  the incremental value was redundant.

@TheXankriegor — this catch-up assumption is the one thing worth a sanity check; flag
it if SystemHeat relies on a tighter `LastUpdateTime` than the full-proto cadence
provides.

## Testing
- All seven `XML_COMPAT/SystemHeat/*.xml` files validated as well-formed XML.
- In-game: fission reactors/engines no longer emit per-second `LastUpdateTime`
  field-change log lines; reactor/loop state still syncs to other players.

## Note (out of scope)
The per-change log line itself comes from LMP's `VesselPartSyncFieldEvents`, which
logs unconditionally on every field send. Any chatty tracked field from any pack will
still write to `KSP.log`; a durable fix (gating those logs behind a debug flag)
belongs in the LunaMultiplayer repo, not here.